### PR TITLE
#22 Remove unnecessary return statement from events

### DIFF
--- a/src/reducers/events.js
+++ b/src/reducers/events.js
@@ -5,9 +5,7 @@ const defaultState = [];
 
 export default handleActions(
   {
-    [getEventsFulfilled]: (state, { payload }) => {
-      return payload;
-    },
+    [getEventsFulfilled]: (state, { payload }) => payload,
   },
   defaultState,
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Events had an unnecessary return statement inside 'getEventsFulfilled' function

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[#22](https://github.com/DAVFoundation/xplore/issues/22)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
