### PR TITLE
#28 Add getTransactionCount to actions

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,5 +1,5 @@
 import { createAction } from 'redux-actions';
-import { getBlocks as getBlocksCall, getAccounts as getAccountsCall, getTransactions as getTransactionsCall, getEvents as getEventsCall } from '../lib/blockchain';
+import { getBlocks as getBlocksCall, getAccounts as getAccountsCall, getTransactions as getTransactionsCall, getEvents as getEventsCall, getTransactionCount as getTransactionCountCall } from '../lib/blockchain';
 
 export const getEvents = createAction('GET_EVENTS', getEventsCall);
 
@@ -18,3 +18,5 @@ export const getTransactions = createAction('GET_TRANSACTIONS', getTransactionsC
 export const getTransactionsFulfilled = createAction('GET_TRANSACTIONS_FULFILLED');
 
 export const submitSearchForm = createAction('SUBMIT_SEARCH_FORM');
+
+export const getTransactionCount = createAction('GET_TRANSACTION_COUNT', getTransactionCountCall);

--- a/test/specs/actions/getTransactionCount.spec.js
+++ b/test/specs/actions/getTransactionCount.spec.js
@@ -1,6 +1,6 @@
 import { getTransactionCount } from '../../../src/actions';
 
-describe('actions', () => {
+describe('getTransactionCount action', () => {
   it('should create an action to get transaction count', () => {
     const block = 1;
     const expectedAction = {

--- a/test/specs/actions/getTransactionCount.spec.js
+++ b/test/specs/actions/getTransactionCount.spec.js
@@ -1,0 +1,11 @@
+import { getTransactionCount } from '../../../src/actions';
+
+describe('actions', () => {
+  it('should create an action to get transaction count', () => {
+    const block = 1;
+    const expectedAction = {
+      type: 'GET_TRANSACTION_COUNT'
+    };
+    expect(getTransactionCount(block)).toEqual(expectedAction);
+  });
+});


### PR DESCRIPTION
## Description
Created a new method `getTransactionCount` which calls `createAction` with `'GET_TRANSACTION_COUNT'` and `getTransactionCountCall` as parameters. Also added a test.

## Related Issue
https://github.com/DAVFoundation/xplore/issues/28

## Motivation and Context
Helps provide a means to get the number of transactions in a block.

## How Has This Been Tested?
Ran `npm test` and also checked that nothing has broken on the app.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
