### PR TITLE
added space between the balance value and ETH

### DIFF
--- a/src/components/AccountBalance.jsx
+++ b/src/components/AccountBalance.jsx
@@ -13,8 +13,7 @@ class AccountBalance extends Component {
         </div>
         <div className="col-xs-6 text-right">
           <p>
-            <strong>{this.props.balance}</strong>
-            ETH
+            <strong>{this.props.balance}</strong> ETH
           </p>
         </div>
       </div>  


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Super minor fix. 
Added the space between the balance and the `ETH` text.

![image](https://user-images.githubusercontent.com/2767425/38131791-fbc432d8-3425-11e8-979d-961287e6e436.png)
