### PR TITLE
Display latest block number in header

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -62,4 +62,6 @@ export const getLatestBlockNumber = createAction(
   getLatestBlockCall,
 );
 
+export const getLatestBlockFulfilled = createAction('GET_LATEST_BLOCK_FULFILLED');
+
 export const getRpcServer = createAction('GET_RPC_SERVER', getRpcServerCall);

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -6,7 +6,7 @@ import SearchFormContainer from '../containers/SearchFormContainer.jsx';
 import HeaderSectionsContainer from '../containers/HeaderSectionsContainer.jsx';
 import TransactionsContainer from '../containers/TransactionsContainer.jsx';
 import EventsContainer from '../containers/EventsContainer.jsx';
-import {getBlocks, getAccounts, getTransactions, getLatestTransaction, getEvents} from '../actions';
+import {getBlocks, getAccounts, getTransactions, getLatestTransaction, getLatestBlock, getEvents} from '../actions';
 import '../static/css/style.css';
 
 class App extends Component {
@@ -17,6 +17,7 @@ class App extends Component {
     store.dispatch(getAccounts());
     store.dispatch(getTransactions());
     store.dispatch(getLatestTransaction());
+    store.dispatch(getLatestBlock());
   }
 
   render() {

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -6,7 +6,7 @@ import SearchFormContainer from '../containers/SearchFormContainer.jsx';
 import HeaderSectionsContainer from '../containers/HeaderSectionsContainer.jsx';
 import TransactionsContainer from '../containers/TransactionsContainer.jsx';
 import EventsContainer from '../containers/EventsContainer.jsx';
-import {getBlocks, getAccounts, getTransactions, getLatestTransaction, getLatestBlock, getEvents} from '../actions';
+import {getBlocks, getAccounts, getTransactions, getLatestTransaction, getLatestBlockNumber, getEvents} from '../actions';
 import '../static/css/style.css';
 
 class App extends Component {
@@ -17,7 +17,7 @@ class App extends Component {
     store.dispatch(getAccounts());
     store.dispatch(getTransactions());
     store.dispatch(getLatestTransaction());
-    store.dispatch(getLatestBlock());
+    store.dispatch(getLatestBlockNumber());
   }
 
   render() {

--- a/src/lib/blockchain.js
+++ b/src/lib/blockchain.js
@@ -139,18 +139,18 @@ export const search = query => {
   }
 
   switch (type) {
-    case 'tx':
-      web3.eth.getTransaction(query).then(tx => {
-        console.log(tx);
-      });
-      break;
-    case 'block':
-      web3.eth.getBlock(parseInt(query)).then(block => {
-        console.log(block);
-      });
-      break;
-    case 'address':
-      break;
+  case 'tx':
+    web3.eth.getTransaction(query).then(tx => {
+      console.log(tx);
+    });
+    break;
+  case 'block':
+    web3.eth.getBlock(parseInt(query)).then(block => {
+      console.log(block);
+    });
+    break;
+  case 'address':
+    break;
   }
 };
 

--- a/src/reducers/headerSections.js
+++ b/src/reducers/headerSections.js
@@ -63,8 +63,8 @@ export default handleActions(
     },
     [getLatestBlockFulfilled]: (state, {payload}) => {
       const newState = deepCopyState(state);
-      newState.blockList.map((block) => {
-        if (block.tag === 'lastBlock') block.value = payload.toString();
+      newState.sectionList.map((section) => {
+        if (section.tag === 'lastBlock') section.value = payload.toString();
       });
       return newState; 
     },

--- a/src/reducers/headerSections.js
+++ b/src/reducers/headerSections.js
@@ -1,5 +1,5 @@
 import { handleActions } from 'redux-actions';
-import { getRpcServer, getLatestTransactionFulfilled } from '../actions';
+import { getRpcServer, getLatestTransactionFulfilled, getLatestBlockFulfilled} from '../actions';
 import { deepCopyState } from '../lib/utils';
 
 const initialState = {
@@ -61,6 +61,14 @@ export default handleActions(
       });
       return newState;
     },
+    [getLatestBlockFulfilled]: (state, {payload}) => {
+      const newState = deepCopyState(state);
+      newState.blockList.map((block) => {
+        if (block.tag === 'lastBlock') block.value = payload.toString();
+      });
+      return newState; 
+    },
   },
   initialState,
 );
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Show latest block number in the header. @TalAter and @debragail let me know what you think especially in headerSections.js, see my comments. Is that the standard way of using actions to change state? It feels very inelegant.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#78 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="1391" alt="screen shot 2018-12-24 at 9 27 12 pm" src="https://user-images.githubusercontent.com/11747211/50400589-b8622380-07c2-11e9-894c-6cef153d70f7.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
